### PR TITLE
feat: added public registry pull through cache to avoid rate limits

### DIFF
--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: captain
 servers: 1
 agents: 5
-# registries:
+registries:
 #   create:
 #     name: docker-io # name of the registry container
 #     proxy:
@@ -18,6 +18,30 @@ agents: 5
 #       "docker.io":
 #         endpoint:
 #           - http://docker-io:5000
+  config: | 
+    mirrors:
+      "docker.io":
+        endpoint:
+          - http://49.13.66.109:5000
+      "quay.io":
+        endpoint:
+          - http://49.13.66.109:5001
+      "ghcr.io":
+        endpoint:
+          - http://49.13.66.109:5002
+      "gcr.io":
+        endpoint:
+          - http://49.13.66.109:5003
+      "public.ecr.aws":
+        endpoint:
+          - http://49.13.66.109:5004
+      "mcr.microsoft.com":
+        endpoint:
+          - http://49.13.66.109:5005
+      "registry.gitlab.com":
+        endpoint:
+          - http://49.13.66.109:5006
+          
 options:
   k3d:
     disableLoadbalancer: true


### PR DESCRIPTION
This is using a VM we have in hetzner. All of our static dev environments have been whitelisted. Codespaces + anything that is ephemeral needs to be whitelisted manually here:
https://console.hetzner.cloud/projects

We get 20TB of monthly transfer with hetzner for free so we may want to consider just keeping it publicly accessible

Deployed here:

https://github.com/GlueOps/docker-compose-container-registry-pull-through-caches