### PR TITLE
feat: adding another node for glueops platform. Specifically for argocd-application-controller

### DIFF
--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -3,7 +3,7 @@ kind: Simple
 metadata:
   name: captain
 servers: 1
-agents: 5
+agents: 6
 image: rancher/k3s:v1.28.9-k3s1
 registries:
 #   create:
@@ -64,3 +64,6 @@ options:
       - label: glueops.dev/role=glueops-platform 
         nodeFilters:
           - agent:1,2,3
+      - label: glueops.dev/role=glueops-platform-argocd-app-controller
+        nodeFilters:
+          - agent:4


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Increased the number of agents from 5 to 6 in the `k3d-config.yaml` file.
- Added a new node label `glueops.dev/role=glueops-platform-argocd-app-controller`.
- Assigned the new label to agent 4 to support the ArgoCD application controller.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>k3d-config.yaml</strong><dd><code>Add new node for ArgoCD application controller in k3d config</code></dd></summary>
<hr>

k3d-config.yaml
<li>Increased the number of agents from 5 to 6.<br> <li> Added a new node label <br><code>glueops.dev/role=glueops-platform-argocd-app-controller</code>.<br> <li> Assigned the new label to agent 4.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/k3d/pull/8/files#diff-b4a269553cacf310c6521e76fbb6104e7eeef090bde29f7e23fa4ad3afc0c623">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

