### PR TITLE
feat: update k3d-config.yaml to lock down kubeapi port

### DIFF
--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -4,6 +4,10 @@ metadata:
   name: captain
 servers: 1
 agents: 6
+kubeAPI: # same as `--api-port myhost.my.domain:6445` (where the name would resolve to 127.0.0.1)
+  host: "127.0.0.1" # important for the `server` setting in the kubeconfig
+  hostIP: "127.0.0.1" # where the Kubernetes API will be listening on
+  hostPort: "6443" # where the Kubernetes API listening port will be mapped to on your host system
 image: rancher/k3s:v1.31.10-k3s1@sha256:8c7032ab267c3a571bac4fafffbb54e249386dbc73ebe5532fb390fa998a7936
 env:
   - envVar: K3S_DEBUG=true

--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: captain
 servers: 1
 agents: 6
-kubeAPI: # same as `--api-port myhost.my.domain:6445` (where the name would resolve to 127.0.0.1)
+kubeAPI: # same as `--api-port myhost.my.domain:6443` (where the name would resolve to 127.0.0.1)
   host: "127.0.0.1" # important for the `server` setting in the kubeconfig
   hostIP: "127.0.0.1" # where the Kubernetes API will be listening on
   hostPort: "6443" # where the Kubernetes API listening port will be mapped to on your host system


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure kubeAPI port binding for k3d cluster

- Lock down API server to localhost (127.0.0.1)

- Set explicit port mapping to 6443


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["k3d cluster"] --> B["kubeAPI configuration"]
  B --> C["host: 127.0.0.1"]
  B --> D["hostIP: 127.0.0.1"]
  B --> E["hostPort: 6443"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>k3d-config.yaml</strong><dd><code>Add kubeAPI port configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k3d-config.yaml

<ul><li>Add kubeAPI configuration section<br> <li> Set host and hostIP to 127.0.0.1 for localhost binding<br> <li> Configure hostPort to 6443 for API server access<br> <li> Include explanatory comments for configuration options</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/k3d/pull/48/files#diff-b4a269553cacf310c6521e76fbb6104e7eeef090bde29f7e23fa4ad3afc0c623">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

