### PR TITLE
feat: migrating to registry caches

### DIFF
--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -8,52 +8,11 @@ kubeAPI: # same as `--api-port myhost.my.domain:6443` (where the name would reso
   host: "127.0.0.1" # important for the `server` setting in the kubeconfig
   hostIP: "127.0.0.1" # where the Kubernetes API will be listening on
   hostPort: "6443" # where the Kubernetes API listening port will be mapped to on your host system
-image: rancher/k3s:v1.31.10-k3s1@sha256:8c7032ab267c3a571bac4fafffbb54e249386dbc73ebe5532fb390fa998a7936
+image: replicas.mirror.gpkg.io/proxy-docker-io/rancher/k3s:v1.31.10-k3s1@sha256:8c7032ab267c3a571bac4fafffbb54e249386dbc73ebe5532fb390fa998a7936
 env:
   - envVar: K3S_DEBUG=true
     nodeFilters:
       - server:*
-registries:
-#   create:
-#     name: docker-io # name of the registry container
-#     proxy:
-#       remoteURL: https://registry-1.docker.io # proxy DockerHub
-#       username: <DOCKER_USERNAME>
-#       password: <DOCKER_PASSWORD>
-#     volumes:
-#       - /tmp/reg:/var/lib/registry # persist data locally in /tmp/reg
-#   config: | # tell K3s to use this registry when pulling from DockerHub
-#     mirrors:
-#       "docker.io":
-#         endpoint:
-#           - http://docker-io:5000
-  config: | 
-    mirrors:
-      "docker.io":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5000
-      "quay.io":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5001
-      "ghcr.io":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5002
-      "gcr.io":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5003
-      "public.ecr.aws":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5004
-      "mcr.microsoft.com":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5005
-      "registry.gitlab.com":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5006
-      "registry.k8s.io":
-        endpoint:
-          - http://dev-only-registry.glueopshosted.com:5007
-          
 options:
   k3d:
     disableLoadbalancer: true


### PR DESCRIPTION
### **User description**
- This prevents the need from having to manually remove the registries section when deploying for k3d users.
- This allows commonly used images to come from the cache and private images to remain private by not being cached outside of the cluster


___

### **PR Type**
Enhancement


___

### **Description**
- Replace local registry mirrors with external cache proxy

- Remove complex multi-registry mirror configuration

- Update K3s image to use replicas.mirror.gpkg.io proxy

- Simplify k3d configuration for easier deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local Registry Mirrors"] -- "replaced by" --> B["External Cache Proxy"]
  C["K3s Image"] -- "updated to use" --> D["replicas.mirror.gpkg.io"]
  E["Complex Config"] -- "simplified to" --> F["Streamlined Setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>k3d-config.yaml</strong><dd><code>Replace local registry mirrors with external cache proxy</code>&nbsp; </dd></summary>
<hr>

k3d-config.yaml

<ul><li>Updated K3s image to use <code>replicas.mirror.gpkg.io</code> proxy<br> <li> Removed entire <code>registries</code> section with local mirror endpoints<br> <li> Eliminated configuration for multiple registry mirrors (docker.io, <br>quay.io, ghcr.io, etc.)<br> <li> Simplified k3d configuration by removing registry complexity</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/k3d/pull/51/files#diff-b4a269553cacf310c6521e76fbb6104e7eeef090bde29f7e23fa4ad3afc0c623">+1/-42</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

